### PR TITLE
remove 'get' de array de dependencias do reviewchart

### DIFF
--- a/src/components/reviewsChart/index.tsx
+++ b/src/components/reviewsChart/index.tsx
@@ -39,7 +39,7 @@ export const ReviewsChart = ({ id, height, width }: ReviewsChartProps) => {
       }
     };
     fetchData();
-  }, [get, id]);
+  }, [id]);
 
   const chartData = {
     labels: apiData ? apiData.labels : [],


### PR DESCRIPTION
remove 'get' de array de dependências do useEffect() no reviewchart que possuia comportamento errático ao consumir `useApiProvider`