### PR TITLE
Bugfix/pisd 281 corrigir select de faixas

### DIFF
--- a/src/app/atleta/perfil/[id]/page.tsx
+++ b/src/app/atleta/perfil/[id]/page.tsx
@@ -22,7 +22,15 @@ type Props = {
 };
 
 const Page = ({ params }: Props) => {
-  const { getInjuries, injuries, injuriesDescription, medals, athleteProfile, getProfile, isLoading } = useAthleteProvider();
+  const {
+    getInjuries,
+    injuries,
+    injuriesDescription,
+    medals,
+    athleteProfile,
+    getProfile,
+    isLoading,
+  } = useAthleteProvider();
 
   const router = useRouter();
   const [lesoes, setLesoes] = useState<string[] | null>(null);
@@ -32,8 +40,8 @@ const Page = ({ params }: Props) => {
   const [medalhaOuro, setMedalhaOuro] = useState<number>(0);
   const [medalhaPrata, setMedalhaPrata] = useState<number>(0);
   const [medalhaBronze, setMedalhaBronze] = useState<number>(0);
-  const [activeButton, setActiveButton] = useState('Gráfico');
-  const [id, setId] = useState<number | null>(null)
+  const [activeButton, setActiveButton] = useState("Gráfico");
+  const [id, setId] = useState<number | null>(null);
 
   const handleButtonClick = (buttonLabel: string, onClick: () => void) => {
     untoggleAll();
@@ -68,23 +76,27 @@ const Page = ({ params }: Props) => {
   };
 
   useEffect(() => {
-    if(params.id && id == null)  {
-      setId(parseInt(params.id))
-      getProfile(params.id)
+    if (params.id && id == null) {
+      setId(parseInt(params.id));
+      getProfile(params.id);
     }
-  }, [params.id])
+  }, [params.id]);
 
   const athleteInfo = [
     { label: athleteProfile?.faixa },
     { label: `${athleteProfile?.idade} anos` },
-    { label: athleteProfile?.categoria ? athleteProfile?.categoria : "Sem categoria" },
+    {
+      label: athleteProfile?.categoria
+        ? athleteProfile?.categoria
+        : "Sem categoria",
+    },
   ];
 
   const buttons = [
-    { label: 'Gráfico', onClick: handleGraficoClick },
-    { label: 'Lesões', onClick: handleLesoesClick },
-    { label: 'Frequência', onClick: handleFrequenciaClick },
-    { label: 'Qualitativos', onClick: handleQualitativoClick },
+    { label: "Gráfico", onClick: handleGraficoClick },
+    { label: "Lesões", onClick: handleLesoesClick },
+    { label: "Frequência", onClick: handleFrequenciaClick },
+    { label: "Qualitativos", onClick: handleQualitativoClick },
   ];
 
   const screenSize = useScreenSize();
@@ -92,13 +104,13 @@ const Page = ({ params }: Props) => {
   useEffect(() => {
     medals?.forEach((medalha: { posicao: string; quantidade: number }) => {
       switch (medalha.posicao) {
-          case 'Medalha de ouro':
+        case "Medalha de ouro":
           setMedalhaOuro(medalha.quantidade);
           break;
-          case 'Medalha de prata':
+        case "Medalha de prata":
           setMedalhaPrata(medalha.quantidade);
           break;
-          case 'Medalha de bronze':
+        case "Medalha de bronze":
           setMedalhaBronze(medalha.quantidade);
           break;
         default:
@@ -118,8 +130,8 @@ const Page = ({ params }: Props) => {
           active={activeButton === button.label}
           className={`lg:mt-2 lg:px-4 lg:py-2 lg:text-lg text-xs py-2 px-[12px] rounded-md transition delay-100 duration-300 ease-in-out ${
             activeButton === button.label
-              ? 'bg-white text-winePattern font-semibold'
-              : ''
+              ? "bg-white text-winePattern font-semibold"
+              : ""
           }`}
         />
       ))}
@@ -129,7 +141,10 @@ const Page = ({ params }: Props) => {
   const renderAthleteInfo = () => (
     <div className="flex flex-col items-center space-y-2 lg:space-y-6">
       {athleteInfo.map((info, index) => (
-        <div key={index} className="bg-gray-300 p-2 lg:p-5 rounded-md text-center text-black flex justify-center items-center w-40 lg:w-60 h-7">
+        <div
+          key={index}
+          className="bg-gray-300 p-2 lg:p-5 rounded-md text-center text-black flex justify-center items-center w-40 lg:w-60 h-7"
+        >
           <h4 className="text-lg font-semibold">{info.label}</h4>
         </div>
       ))}
@@ -142,19 +157,35 @@ const Page = ({ params }: Props) => {
         <div>
           <div className="flex justify-center space-x-6 mb-4 mt-6 lg:space-x-10 lg:mt-8 lg:mb-8">
             {/* <IconButton href="/comparison" src="/icons/avaliacao_fisica.png" alt="Avaliação Física Individual" /> */}
-            <IconButton href={`${params.id}/cadastrar/avaliacaoFisica`} src="/icons/avaliacao_fisica.png" alt="Edição" />
-            <IconButton href={`${params.id}/cadastrar/campeonato`} src="/icons/campeonato.png" alt="Campeonato" />
-            <IconButton href={`${params.id}/postura`} src="/icons/posture_icon.png" alt="Postura" />
-            <IconButton href={`/atleta/editar/${params.id}`} src="/icons/ferramenta-lapis.png" alt="Edição" />
+            <IconButton
+              href={`${params.id}/cadastrar/avaliacaoFisica`}
+              src="/icons/avaliacao_fisica.png"
+              alt="Edição"
+            />
+            <IconButton
+              href={`${params.id}/cadastrar/campeonato`}
+              src="/icons/campeonato.png"
+              alt="Campeonato"
+            />
+            <IconButton
+              href={`${params.id}/postura`}
+              src="/icons/posture_icon.png"
+              alt="Postura"
+            />
+            <IconButton
+              href={`/atleta/editar/${params.id}`}
+              src="/icons/ferramenta-lapis.png"
+              alt="Edição"
+            />
             {/* <IconButton href={`/atleta/perfil/${params.id}/cadastrar/campeonato`} src="/icons/campeonato.png" alt="Campeonato" /> */}
             {/* <IconButton href={`/postura/${params.id}`} src="/icons/posture_icon.png" alt="Postura" /> */}
           </div>
           <AvatarAtleta
             id={params.id}
             name={athleteProfile?.nome}
-            belt={athleteProfile?.faixa}
             photo={athleteProfile?.foto}
-            size={screenSize.width > 1024 ? "big" : "small"}
+            size={"big"}
+            className={screenSize.width < 600 ? "scale-[.85]" : undefined}
           />
           <section>
             <div className="flex flex-col items-center space-y-2 lg:space-y-6">
@@ -184,18 +215,57 @@ const Page = ({ params }: Props) => {
               </div>
             </div>
           </section>
-        </div> {/* Seção lateral Fim */}
-        <div> {/* Seção Botões Começo */}
+        </div>{" "}
+        {/* Seção lateral Fim */}
+        <div>
+          {" "}
+          {/* Seção Botões Começo */}
           {renderButtons()}
           <div className="max-w-full">
             {qualitativos && <div></div>}
-            {frequencia && <div className="mt-4 lg:mt-32"><Frequency height={screenSize.width > 1024 ? 200 : 100} width={screenSize.width > 1024 ? 200 : 100} id={params.id} /></div>}
-            {grafico && <div className="lg:mt-24"><ReviewsChart height={screenSize.width > 1024 ? 524 : 256} width={screenSize.width > 1024 ? 524 : 256} id={params.id} /></div>}
+            {frequencia && (
+              <div className="mt-4 lg:mt-32">
+                <Frequency
+                  height={screenSize.width > 1024 ? 200 : 100}
+                  width={screenSize.width > 1024 ? 200 : 100}
+                  id={params.id}
+                />
+              </div>
+            )}
+            {grafico && (
+              <div className="lg:mt-24">
+                <ReviewsChart
+                  height={screenSize.width > 1024 ? 524 : 256}
+                  width={screenSize.width > 1024 ? 524 : 256}
+                  id={params.id}
+                />
+              </div>
+            )}
             {lesoes && (
               <div>
                 <div className="flex flex-row items-stretch justify-center mt-4 lg:mt-12 lg:gap-6 -z-50">
-                  <Injuries injuries={injuries} type="front" width={screenSize.width > 1024 ? "248px" : "150px"} height={screenSize.width > 1024 ? "400px" : "200px"} viewBoxValue={screenSize.width > 1024 ? "1000 15400 19000 5000" : "1000 12000 19000 5000"} />
-                  <Injuries injuries={injuries} type="back" width={screenSize.width > 1024 ? "232px" : "134px"} height={screenSize.width > 1024 ? "400px" : "200px"} viewBoxValue={screenSize.width > 1024 ? "1000 4000 20000 27000" : "1000 0 20000 27000"} />
+                  <Injuries
+                    injuries={injuries}
+                    type="front"
+                    width={screenSize.width > 1024 ? "248px" : "150px"}
+                    height={screenSize.width > 1024 ? "400px" : "200px"}
+                    viewBoxValue={
+                      screenSize.width > 1024
+                        ? "1000 15400 19000 5000"
+                        : "1000 12000 19000 5000"
+                    }
+                  />
+                  <Injuries
+                    injuries={injuries}
+                    type="back"
+                    width={screenSize.width > 1024 ? "232px" : "134px"}
+                    height={screenSize.width > 1024 ? "400px" : "200px"}
+                    viewBoxValue={
+                      screenSize.width > 1024
+                        ? "1000 4000 20000 27000"
+                        : "1000 0 20000 27000"
+                    }
+                  />
                 </div>
                 <div className="flex mb-2">
                   <Button
@@ -208,17 +278,23 @@ const Page = ({ params }: Props) => {
                   ></Button>
                 </div>
                 <div className="flex flex-col-reverse custom-scrollbar mx-auto max-h-24 lg:max-h-40 scroll-auto overflow-y-auto justify-center bg-white rounded-lg p-4 lg:-mt-4 max-w-xs lg:min-w-fit lg:max-w-md ">
-                  {(!isLoading && injuriesDescription.length <= 0) && <h3 className="text-sm lg:text-lg font-semibold">O atleta não possui lesão registrada</h3>}
-                  {
-                    injuriesDescription.map((injury, index) => (
-                      <p key={index} className="leading-relaxed text-xs lg:text-sm text-wrap text-transform: capitalize">{`${injury} \n`}</p>
-                    ))
-                  }
+                  {!isLoading && injuriesDescription.length <= 0 && (
+                    <h3 className="text-sm lg:text-lg font-semibold">
+                      O atleta não possui lesão registrada
+                    </h3>
+                  )}
+                  {injuriesDescription.map((injury, index) => (
+                    <p
+                      key={index}
+                      className="leading-relaxed text-xs lg:text-sm text-wrap text-transform: capitalize"
+                    >{`${injury} \n`}</p>
+                  ))}
                 </div>
               </div>
             )}
           </div>
-        </div> {/* Seção Botões Fim */}
+        </div>{" "}
+        {/* Seção Botões Fim */}
       </section>
     </div>
   );

--- a/src/components/avatarAtleta/avatarAtleta.module.css
+++ b/src/components/avatarAtleta/avatarAtleta.module.css
@@ -3,7 +3,6 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  cursor: pointer;
   position: relative;
   padding-top: 10px;
 }
@@ -61,10 +60,11 @@
 }
 
 .photoBgBig {
-  width: 200px;
-  height: 200px;
+  transform: translateY(20px);
+  width: 190px;
+  height: 190px;
   background-color: #5f0404;
-  border: 2px solid #fff;
+  border: 2px solid #350202;
   border-radius: 50%;
 }
 
@@ -94,7 +94,7 @@
   background-color: #5f0404;
   box-sizing: border-box;
   border-radius: 10px;
-  border: 2px solid;
+  border: 2px solid #350202;
   text-align: center;
   z-index: 2;
   overflow: scroll;

--- a/src/components/avatarAtleta/page.tsx
+++ b/src/components/avatarAtleta/page.tsx
@@ -13,9 +13,10 @@ type Props = {
   photo?: string;
   size: "small" | "big";
   belt?: (typeof Faixas)[number];
+  className?: string | undefined;
 };
 
-const AvatarAtleta = ({ id, name, photo, belt, size }: Props) => {
+const AvatarAtleta = ({ id, name, photo, belt, size, className }: Props) => {
   const router = useRouter();
 
   const beltsColor = {
@@ -94,42 +95,62 @@ const AvatarAtleta = ({ id, name, photo, belt, size }: Props) => {
     },
   };
 
-  if (size === "big" && belt) {
-    return (
-      <div
-        className={styles.container}
-        onClick={() => alert(`Você clicou no ${name}`)}
-      >
+  if (size === "big") {
+    if (belt) {
+      return (
         <div
-          className={styles.photoBgBig}
-          style={{
-            background: `${beltsColor[belt].background}`,
-            borderColor: `${beltsColor[belt].backgroundBorder}`,
-          }}
-        ></div>
-        {photo && (
-          <img className={styles.photoBig} src={photo} alt={`Foto de ${name}`} />
-        )}
-        <div
-          className={styles.nameContainerBig}
-          style={{
-            background: `${beltsColor[belt].background}`,
-            borderColor: `${beltsColor[belt].nameBorder}`,
-          }}
+          className={styles.container}
+          onClick={() => alert(`Você clicou no ${name}`)}
         >
-          <p style={{ color: `${beltsColor[belt].name}` }}>{name}</p>
+          <div
+            className={styles.photoBgBig}
+            style={{
+              background: `${beltsColor[belt].background}`,
+              borderColor: `${beltsColor[belt].backgroundBorder}`,
+            }}
+          ></div>
+          {photo && (
+            <img
+              className={styles.photoBig}
+              src={photo}
+              alt={`Foto de ${name}`}
+            />
+          )}
+          <div
+            className={styles.nameContainerBig}
+            style={{
+              background: `${beltsColor[belt].background}`,
+              borderColor: `${beltsColor[belt].nameBorder}`,
+            }}
+          >
+            <p style={{ color: `${beltsColor[belt].name}` }}>{name}</p>
+          </div>
         </div>
-      </div>
-    );
+      );
+    } else {
+      return (
+        <div className={`${styles.container} ${className}`}>
+          <div className={styles.photoBgBig}></div>
+          <img
+            className={styles.photoBig}
+            src={photo}
+            alt={`Foto de ${name}`}
+          />
+          <div className={styles.nameContainerBig}>
+            <p>{name}</p>
+          </div>
+        </div>
+      );
+    }
   } else if (size === "small") {
     return (
       <div
         className={styles.container}
+        style={{ cursor: "pointer" }}
         onClick={() => router.push(`/atleta/perfil/${id}`)}
       >
         <div className={styles.photoBg}></div>
         <img className={styles.photo} src={photo} alt={`Foto de ${name}`} />
-        {/* <Image className={styles.photo} src={photo} alt={`Foto de ${name}`} height={200} width={200}/> */}
         <div className={styles.nameContainer}>
           <p>{name}</p>
         </div>

--- a/src/components/formAtleta/index.tsx
+++ b/src/components/formAtleta/index.tsx
@@ -199,8 +199,8 @@ const FormAtleta = ({ atleta, method }: Props) => {
               </option>
               <option value="branca">Branca</option>
               <option value="cinza">Cinza</option>
-              <option value="azulClaro">Azul claro</option>
-              <option value="azulEscuro">Azul escuro</option>
+              <option value="azulClaro">Azul clara</option>
+              <option value="azulEscuro">Azul escura</option>
               <option value="amarela">Amarela</option>
               <option value="laranja">Laranja</option>
               <option value="verde">Verde</option>

--- a/src/contexts/api/api.tsx
+++ b/src/contexts/api/api.tsx
@@ -67,8 +67,6 @@ export const ApiProvider = ({ children }: { children: React.ReactNode }) => {
     request: Promise<any>,
     displayOptions?: DisplayOptions
   ) {
-    console.log("toastOptions:", displayOptions);
-
     // Monitora o sucesso
     displayOptions?.toastSuccess &&
       request.then((data: any) => {
@@ -185,7 +183,9 @@ export const ApiProvider = ({ children }: { children: React.ReactNode }) => {
   };
 
   return (
-    <ApiContext.Provider value={{ get, post, put, patch, remove, isLoadingAPI }}>
+    <ApiContext.Provider
+      value={{ get, post, put, patch, remove, isLoadingAPI }}
+    >
       {isLoadingAPI && <Loading />}
       {children}
     </ApiContext.Provider>


### PR DESCRIPTION
### Tela Cadastro Atleta / Componente Avatar Atleta
- Corrigido o gênero das palavras 'Azul Escuro' e 'Azul Claro', para 'Azul Escura' e 'Azul Clara', uma vez que estes fazem alusão a faixa (gênero feminino).
O contrato do back continua exigindo os valores 'azulEscuro' e 'azulClaro'. Foi definido alterar somente a exibição para o usuário no front, por hora.

- O componente avatarAtleta da tela base Perfil do Atleta, não mais consome o avatarAtleta 'small' (que foi criado no passado com o  objeto de ser consumido somente pela tela Busca Atleta). Ele agora consome sempre o 'big'.

- Quando a tela base perfil do atleta está em um dispositivo mobile, é aplicado uma redução de 15% no avatarAtleta.

- O componente avatarAtleta sofreu alguns ajustes de estilização: agora o círculo bg tem 10px a menos, e é posicionado 20px mais abaixo, deixando a foto do atleta 'vazar' mais.



> Peço perdão a todos pelo componente avatarAtleta. Ter que reler o código fez meus olhos sangrarem.
> Esse componente foi criado em meados de Fevereiro, quando faziam menos de 30 dias que eu havia aprendido o que significava a palavra React. A vontade de reescrever tudo é grande, mas temos que avançar com o projeto. Talvez no futuro ocioso.