### PR TITLE
feat: adicionar modal para exibir campeonatos do atleta

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 ## Índice
 
+- [Índice](#índice)
 - [Descrição do Projeto](#descrição-do-projeto)
 - [Tecnologias Utilizadas](#tecnologias-utilizadas)
 - [Funcionalidades](#funcionalidades)
@@ -67,4 +68,5 @@ http://institutodivino.com.br/
 - [Michel Machado](https://github.com/Michel-Machado)
 - [Charles Anderson](https://github.com/charlesanderson25)
 - [Paulo Mota](https://github.com/Roberto-Mota)
+- [Rafael Palau](https://github.com/RafaPalau)
 - [Wilson Alves](https://github.com/Wilrrama)

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -1,21 +1,30 @@
-import {axios} from "@/api/api";
+import { axios } from "@/api/api";
 
 export const getAtletas = (page: number, elementsQty: number | null) => {
-    if (elementsQty) return axios.get(`/atleta?page=${page}&size=${elementsQty}`);
-    return axios.get(`/atleta?page=${page}`)
-}
+  if (elementsQty) return axios.get(`/atleta?page=${page}&size=${elementsQty}`);
+  return axios.get(`/atleta?page=${page}`);
+};
 
-export const getAtletasByName = (name:string, page: number, elementsQty: number | null) => {
-    if (elementsQty) return axios.get(`/atleta/nome/${name}?page=${page}&size=${elementsQty}`);
-    return axios.get(`/atleta/nome/${name}?page=${page}`);
-}
+export const getAtletasByName = (
+  name: string,
+  page: number,
+  elementsQty: number | null
+) => {
+  if (elementsQty)
+    return axios.get(`/atleta/nome/${name}?page=${page}&size=${elementsQty}`);
+  return axios.get(`/atleta/nome/${name}?page=${page}`);
+};
 
 export const getAvaliacaoPosturalDatas = (atletaId: number) => {
-    console.log(`Requisição feita para /avaliacaopostural/datas/${atletaId}`)
-    return axios.get(`/avaliacaopostural/datas/${atletaId}`);
-}
+  console.log(`Requisição feita para /avaliacaopostural/datas/${atletaId}`);
+  return axios.get(`/avaliacaopostural/datas/${atletaId}`);
+};
 
 export const getAvaliacaoPostural = (atletaId: number, data: string) => {
-    console.log(`Requisição feita para /avaliacaopostural/${atletaId}/${data}`)
-    return axios.get(`/avaliacaopostural/${atletaId}/${data}`);
-}
+  console.log(`Requisição feita para /avaliacaopostural/${atletaId}/${data}`);
+  return axios.get(`/avaliacaopostural/${atletaId}/${data}`);
+};
+
+export const getCampeonatosByAtleta = (atletaId: number) => {
+  return axios.get(`/campeonato/lista/${atletaId}`);
+};

--- a/src/app/atleta/perfil/[id]/page.tsx
+++ b/src/app/atleta/perfil/[id]/page.tsx
@@ -13,8 +13,8 @@ import MedalSection from "@/components/medalSection";
 import Button from "@/components/ui/button";
 import { useRouter } from "next/navigation";
 import dayjs from "dayjs";
-import Tippy from '@tippyjs/react';
-import 'tippy.js/dist/tippy.css';
+import Tippy from "@tippyjs/react";
+import "tippy.js/dist/tippy.css";
 import Qualitativos from "@/components/qualitativos/index";
 
 type Params = {
@@ -26,7 +26,15 @@ type Props = {
 };
 
 const Page = ({ params }: Props) => {
-  const { getInjuries, injuries, injuriesInfo, medals, athleteProfile, getProfile, isLoading } = useAthleteProvider();
+  const {
+    getInjuries,
+    injuries,
+    injuriesInfo,
+    medals,
+    athleteProfile,
+    getProfile,
+    isLoading,
+  } = useAthleteProvider();
   const router = useRouter();
   const [lesoes, setLesoes] = useState<string[] | null>(null);
   const [grafico, setGrafico] = useState<any | null>(true);
@@ -97,6 +105,10 @@ const Page = ({ params }: Props) => {
   const screenSize = useScreenSize();
 
   useEffect(() => {
+    setMedalhaOuro(0);
+    setMedalhaPrata(0);
+    setMedalhaBronze(0);
+
     medals?.forEach((medalha: { posicao: string; quantidade: number }) => {
       switch (medalha.posicao) {
         case "Medalha de ouro":
@@ -112,7 +124,7 @@ const Page = ({ params }: Props) => {
           break;
       }
     });
-  }, [medals]);
+  }, [medals, params.id]);
 
   const renderButtons = () => (
     <section className="flex mt-6 space-x-2 lg:space-x-6 justify-center">
@@ -151,7 +163,6 @@ const Page = ({ params }: Props) => {
       <section className="flex flex-col lg:flex-row lg:justify-around lg:w-full">
         <div>
           <div className="flex justify-center space-x-6 mb-4 mt-6 lg:space-x-10 lg:mt-8 lg:mb-8">
-            {/* <IconButton href="/comparison" src="/icons/avaliacao_fisica.png" alt="Avaliação Física Individual" /> */}
             <IconButton
               href={`${params.id}/cadastrar/avaliacaoFisica`}
               src="/icons/avaliacao_fisica.png"
@@ -172,8 +183,6 @@ const Page = ({ params }: Props) => {
               src="/icons/ferramenta-lapis.png"
               alt="Edição"
             />
-            {/* <IconButton href={`/atleta/perfil/${params.id}/cadastrar/campeonato`} src="/icons/campeonato.png" alt="Campeonato" /> */}
-            {/* <IconButton href={`/postura/${params.id}`} src="/icons/posture_icon.png" alt="Postura" /> */}
           </div>
           <AvatarAtleta
             id={params.id}
@@ -190,18 +199,23 @@ const Page = ({ params }: Props) => {
                   altText="Ícone Medalha Ouro"
                   ringColor="amber-500"
                   medalCount={medalhaOuro}
+                  athleteId={Number(params.id)}
                 />
+
                 <MedalSection
                   imgSrc="/formAtleta/medals/medalhasCinza2.png"
                   altText="Ícone Medalha Prata"
                   ringColor="zinc-500"
                   medalCount={medalhaPrata}
+                  athleteId={Number(params.id)}
                 />
+
                 <MedalSection
                   imgSrc="/formAtleta/medals/medalhasCinza3.png"
                   altText="Ícone Medalha Bronze"
                   ringColor="copperMedal"
                   medalCount={medalhaBronze}
+                  athleteId={Number(params.id)}
                 />
               </div>
               {renderAthleteInfo()}
@@ -277,18 +291,31 @@ const Page = ({ params }: Props) => {
                   ></Button>
                 </div>
                 <div className="flex flex-col-reverse custom-scrollbar mx-auto max-h-26 lg:max-h-40 scroll-auto overflow-y-auto justify-center bg-white rounded-lg p-4 pt-2 lg:-mt-4 max-w-xs lg:min-w-fit lg:max-w-sm ">
-                  {(!isLoading && injuriesInfo.length <= 0) && <h3 className="text-sm lg:text-lg font-semibold">O atleta não possui lesão registrada</h3>}
-                  {
-                    injuriesInfo.map((injuryInfo, index) => (
-                      <p key={index} className="leading-7 justify-between inline-block align-text-bottom text-xs lg:text-sm text-wrap text-transform: capitalize">
-                        <span className="font-bold">{dayjs(injuryInfo.date).format('DD/MM/YYYY')}</span>
-                        <span className="italic "> {injuryInfo.regiaoLesao}</span>
-                        <Tippy hideOnClick={true} content={injuryInfo.description}>
-                          <span className="cursor-pointer lg:text-base text-lg"> ℹ️</span>
-                        </Tippy>
-                      </p>
-                    ))
-                  }
+                  {!isLoading && injuriesInfo.length <= 0 && (
+                    <h3 className="text-sm lg:text-lg font-semibold">
+                      O atleta não possui lesão registrada
+                    </h3>
+                  )}
+                  {injuriesInfo.map((injuryInfo, index) => (
+                    <p
+                      key={index}
+                      className="leading-7 justify-between inline-block align-text-bottom text-xs lg:text-sm text-wrap text-transform: capitalize"
+                    >
+                      <span className="font-bold">
+                        {dayjs(injuryInfo.date).format("DD/MM/YYYY")}
+                      </span>
+                      <span className="italic "> {injuryInfo.regiaoLesao}</span>
+                      <Tippy
+                        hideOnClick={true}
+                        content={injuryInfo.description}
+                      >
+                        <span className="cursor-pointer lg:text-base text-lg">
+                          {" "}
+                          ℹ️
+                        </span>
+                      </Tippy>
+                    </p>
+                  ))}
                 </div>
               </div>
             )}

--- a/src/app/atleta/perfil/[id]/page.tsx
+++ b/src/app/atleta/perfil/[id]/page.tsx
@@ -169,11 +169,6 @@ const Page = ({ params }: Props) => {
               alt="Edição"
             />
             <IconButton
-              href={`${params.id}/cadastrar/campeonato`}
-              src="/icons/campeonato.png"
-              alt="Campeonato"
-            />
-            <IconButton
               href={`${params.id}/postura`}
               src="/icons/posture_icon.png"
               alt="Postura"

--- a/src/components/medalSection/index.tsx
+++ b/src/components/medalSection/index.tsx
@@ -1,26 +1,110 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
+import Modal from "../modal";
+import { getCampeonatosByAtleta } from "@/api/endpoints";
+import dayjs from "dayjs";
+import "dayjs/locale/pt-br";
 
-type MedalSectionProps = {
+dayjs.locale("pt-br");
+
+const positionMapping: Record<string, string> = {
+  PRIMEIRO: "1º Lugar",
+  SEGUNDO: "2º Lugar",
+  TERCEIRO: "3º Lugar",
+};
+
+interface Campeonato {
+  name: string;
+  date: string;
+  posicaoPodium: string;
+}
+
+interface MedalSectionProps {
   imgSrc: string;
   altText: string;
   ringColor: string;
   medalCount: number;
-};
+  athleteId: number;
+}
 
-const MedalSection = ({ imgSrc, altText, ringColor, medalCount }: MedalSectionProps) => {
-  const ringClass = `hover:ring-2 hover:ring-${ringColor}`;
-  
+const MedalSection = ({ imgSrc, altText, ringColor, medalCount, athleteId }: MedalSectionProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [championships, setChampionships] = useState<Campeonato[]>([]);
+  const [isHovered, setIsHovered] = useState(false);
+  const [currentMedalCount, setCurrentMedalCount] = useState(medalCount); 
+
+  useEffect(() => {
+    setCurrentMedalCount(medalCount); 
+  }, [medalCount, athleteId]);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsLoading(true);
+
+      getCampeonatosByAtleta(athleteId)
+        .then((response: { data: { nome: string; data: string; posicaoPodium: string }[] }) => {
+          const data = response.data.map((champ) => ({
+            name: champ.nome,
+            date: dayjs(champ.data).format("DD/MM/YYYY"),
+            posicaoPodium: champ.posicaoPodium,
+          }));
+          setChampionships(data);
+        })
+        .catch((error: unknown) => {
+          console.error("Erro ao buscar campeonatos:", error);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  }, [isOpen, athleteId]);
+
   return (
-    <section className={`${ringClass} rounded-lg`}>
-      <img
-        src={imgSrc}
-        alt={altText}
-        className="transition delay-100 duration-300 ease-in-out hover:skew-y-6 hover:invert rounded-lg p-1 object-contain w-14 h-14 lg:w-20 lg:h-20"
-      />
-      <div className="lg:text-xl text-white font-semibold text-center">
-        {medalCount}
-      </div>
-    </section>
+    currentMedalCount > 0 && (
+      <>
+        <section 
+          className="cursor-pointer"
+          onClick={() => setIsOpen(true)}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+        >
+          <img
+            src={imgSrc}
+            alt={altText}
+            className={`transition hover:ring-2 hover:invert rounded-lg p-1 object-contain w-14 h-14 lg:w-20 lg:h-20`}
+          />
+          <div className="lg:text-xl text-white font-semibold text-center">{medalCount}</div>
+        </section>
+
+        {isOpen && (
+          <Modal title="Campeonatos" closeModalFunction={() => setIsOpen(false)} showCloseIcon={true} imageSrc="/icons/campeonato.png">
+            {isLoading ? (
+              <p>Carregando...</p>
+            ) : (
+              Object.entries(
+                championships.reduce((acc: Record<string, Campeonato[]>, champ) => {
+                  if (!acc[champ.posicaoPodium]) {
+                    acc[champ.posicaoPodium] = [];
+                  }
+                  acc[champ.posicaoPodium].push(champ);
+                  return acc;
+                }, {})
+              ).map(([position, champs]) => (
+                <div key={position} className="mt-4">
+                  <h3 className="text-lg font-bold text-center">{positionMapping[position] || position}</h3>
+                  <hr className="my-2 border-gray-300" />
+                  {champs.map((champ, index) => (
+                    <p key={index} className="text-sm text-center">
+                      <span className="font-semibold">{champ.name}</span> - {champ.date}
+                    </p>
+                  ))}
+                </div>
+              ))
+            )}
+          </Modal>
+        )}
+      </>
+    )
   );
 };
 

--- a/src/components/medalSection/index.tsx
+++ b/src/components/medalSection/index.tsx
@@ -77,7 +77,13 @@ const MedalSection = ({ imgSrc, altText, ringColor, medalCount, athleteId }: Med
         </section>
 
         {isOpen && (
-          <Modal title="Campeonatos" closeModalFunction={() => setIsOpen(false)} showCloseIcon={true} imageSrc="/icons/campeonato.png">
+          <Modal 
+            title="Campeonatos" 
+            closeModalFunction={() => setIsOpen(false)} 
+            showCloseIcon={true} 
+            imageSrc="/icons/campeonato.png" 
+            imageLink={`${athleteId}/cadastrar/campeonato`}
+          >
             {isLoading ? (
               <p>Carregando...</p>
             ) : (

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from "react";
 import Button from "../ui/button";
+import Link from "next/link";
 
 interface ModalProps {
   title: string;
@@ -11,6 +12,7 @@ interface ModalProps {
   cancelButtonText?: string;
   showCloseIcon?: boolean;
   imageSrc?: string;
+  imageLink?: string;
   children?: React.ReactNode;
 }
 
@@ -25,6 +27,7 @@ const Modal = ({
   showCloseIcon = true,
   children,
   imageSrc,
+  imageLink,
 }: ModalProps) => {
   
   useEffect(() => {
@@ -45,7 +48,13 @@ const Modal = ({
       <div className="relative bg-white rounded-md xl:p-10 lg:p-8 md:p-5 p-5 shadow-lg w-full max-w-md" onClick={(e) => e.stopPropagation()}>
         
         {imageSrc && (
-          <img src={imageSrc} alt="Ícone" className="absolute top-3 left-3 w-8 h-8" />
+          imageLink ? (
+            <Link href={imageLink}>
+              <img src={imageSrc} alt="Ícone" className="absolute top-3 left-3 w-8 h-8 cursor-pointer" />
+            </Link>
+          ) : (
+            <img src={imageSrc} alt="Ícone" className="absolute top-3 left-3 w-8 h-8" />
+          )
         )}
 
         {showCloseIcon && (

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,6 +1,7 @@
+import React, { useEffect } from "react";
 import Button from "../ui/button";
 
-type ModalProps = {
+interface ModalProps {
   title: string;
   text?: string;
   closeModalFunction: () => void;
@@ -9,7 +10,9 @@ type ModalProps = {
   confirmButtonText?: string;
   cancelButtonText?: string;
   showCloseIcon?: boolean;
-};
+  imageSrc?: string;
+  children?: React.ReactNode;
+}
 
 const Modal = ({
   title,
@@ -20,53 +23,55 @@ const Modal = ({
   confirmButtonText = "Confirmar",
   cancelButtonText = "Cancelar",
   showCloseIcon = true,
+  children,
+  imageSrc,
 }: ModalProps) => {
+  
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeModalFunction();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [closeModalFunction]);
+
   return (
-    <div className="relative w-scren min-h-screen flex items-center justify-center">
-      <div className="absolute m-auto mx-auto z-20 lg:max-w-[650px] md:max-w-[500px] sm:max-w-[350px] max-w-[350px] flex items-center justify-center bg-white rounded-md xl:p-10 lg:p-8 md:p-5 p-5">
-        <div>
-          {showCloseIcon && (
-            <button
-              onClick={closeModalFunction}
-              className="absolute block xl:top-[7px] lg:top-[6px] md:top-[5px] top-[5px] xl:right-[10px] lg:right-[9px] md:right-[8px] right-[8px] text-winePattern font-bold xl:text-sm lg:text-xs md:text-xs text-xs p-1"
-            >
-              X
-            </button>
+    <div className="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50" onClick={closeModalFunction}>
+      <div className="relative bg-white rounded-md xl:p-10 lg:p-8 md:p-5 p-5 shadow-lg w-full max-w-md" onClick={(e) => e.stopPropagation()}>
+        
+        {imageSrc && (
+          <img src={imageSrc} alt="Ícone" className="absolute top-3 left-3 w-8 h-8" />
+        )}
+
+        {showCloseIcon && (
+          <button
+            onClick={closeModalFunction}
+            className="absolute top-3 right-3 text-winePattern font-bold text-xl"
+          >
+            X
+          </button>
+        )}
+
+        <h3 className="text-2xl text-winePattern font-bold text-center uppercase">{title}</h3>
+
+        {text && <p className="text-left text-base mt-4">{text}</p>}
+
+        <div className="mt-4">{children}</div>
+
+        <div className="flex flex-col-reverse mt-6 gap-y-4 md:flex-row justify-center items-center">
+          {cancelButtonFunction && (
+            <Button text={cancelButtonText} onClick={cancelButtonFunction} type="button" />
           )}
-
-          <h3 className="xl:text-2xl lg:text-xl md:text-lg text-lg text-winePattern font-bold text-center uppercase">
-            {title}
-          </h3>
-
-          {text && (
-            <p className="text-left xl:text-base lg:text-sm md:text-xs text-xs xl:mt-4 lg:mt-3 md:mt-2 mt-2">
-              {text}
-            </p>
+          {confirmButtonFunction && (
+            <Button text={confirmButtonText} onClick={confirmButtonFunction} type="button" />
           )}
-
-          <div className="flex flex-1 flex-col-reverse mt-12 gap-y-6 gap-x-10 md:flex-row justify-center items-center">
-            {cancelButtonFunction && (
-              <Button
-                text={cancelButtonText}
-                onClick={cancelButtonFunction}
-                type={"button"}
-              />
-            )}
-
-            {confirmButtonFunction && (
-              <Button
-                text={confirmButtonText}
-                onClick={confirmButtonFunction}
-                type={"button"}
-              />
-            )}
-          </div>
         </div>
       </div>
-      <div
-        className="absolute z-10 top-0 bottom-0 left-0 right-0 w-scren min-h-screen"
-        onClick={closeModalFunction}
-      ></div>
     </div>
   );
 };


### PR DESCRIPTION
###  🏆 Adicionar Modal de Campeonatos do Atleta
📌 Descrição
Este PR adiciona um modal exibindo os campeonatos conquistados pelo atleta ao clicar em suas medalhas. Os campeonatos são organizados por posição no pódio (1º, 2º e 3º lugar) e mostram o nome e a data formatada (DD/MM/YYYY).

🎯 Como Testar
- Acesse o perfil de um atleta.
- Clique em uma medalha (ouro, prata ou bronze).
O modal deve exibir corretamente os campeonatos.
- Pressione ESC ou clique fora do modal para fechá-lo.


