### PR TITLE
feat: adicionar modal para exibir campeonatos do atleta [PISD-243]

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@
 
 ## Índice
 
+- [Índice](#índice)
 - [Descrição do Projeto](#descrição-do-projeto)
 - [Tecnologias Utilizadas](#tecnologias-utilizadas)
 - [Funcionalidades](#funcionalidades)
+- [Como rodar o projeto localmente](#como-rodar-o-projeto-localmente)
 - [Pessoas Contribuidoras](#pessoas-contribuidoras)
 
 </font>
@@ -105,4 +107,5 @@ http://institutodivino.com.br/
 - [Michel Machado](https://github.com/Michel-Machado)
 - [Charles Anderson](https://github.com/charlesanderson25)
 - [Paulo Mota](https://github.com/Roberto-Mota)
+- [Rafael Palau](https://github.com/RafaPalau)
 - [Wilson Alves](https://github.com/Wilrrama)

--- a/src/api/endpoints.ts
+++ b/src/api/endpoints.ts
@@ -19,3 +19,7 @@ export const getAvaliacaoPostural = (atletaId: number, data: string) => {
     console.log(`Requisição feita para /avaliacaopostural/${atletaId}/${data}`)
     return axios.get(`/avaliacaopostural/${atletaId}/${data}`);
 }
+
+export const getCampeonatosByAtleta = (atletaId: number) => {
+    return axios.get(`/campeonato/lista/${atletaId}`);
+};

--- a/src/app/atleta/perfil/[id]/page.tsx
+++ b/src/app/atleta/perfil/[id]/page.tsx
@@ -117,6 +117,10 @@ const Page = ({ params }: Props) => {
   const screenSize = useScreenSize();
 
   useEffect(() => {
+    setMedalhaOuro(0);
+    setMedalhaPrata(0);
+    setMedalhaBronze(0);
+
     medals?.forEach((medalha: { posicao: string; quantidade: number }) => {
       switch (medalha.posicao) {
         case "Medalha de ouro":
@@ -132,7 +136,7 @@ const Page = ({ params }: Props) => {
           break;
       }
     });
-  }, [medals]);
+  }, [medals, params.id]);
 
   const renderButtons = () => (
     <section className="flex m-auto mt-6 space-x-2 lg:space-x-6 box-border w-fit">
@@ -236,20 +240,28 @@ const Page = ({ params }: Props) => {
                 <MedalSection
                   imgSrc="/formAtleta/medals/medalhasCinza1.png"
                   altText="Ícone Medalha Ouro"
-                  ringColor="amber-500"
+                  ringColor="gold"
                   medalCount={medalhaOuro}
+                  athleteId={Number(params.id)}
+                  podiumPosition="PRIMEIRO"
                 />
+
                 <MedalSection
                   imgSrc="/formAtleta/medals/medalhasCinza2.png"
                   altText="Ícone Medalha Prata"
-                  ringColor="zinc-500"
+                  ringColor="silver"
                   medalCount={medalhaPrata}
+                  athleteId={Number(params.id)}
+                  podiumPosition="SEGUNDO"
                 />
+
                 <MedalSection
                   imgSrc="/formAtleta/medals/medalhasCinza3.png"
                   altText="Ícone Medalha Bronze"
-                  ringColor="copperMedal"
+                  ringColor="bronze"
                   medalCount={medalhaBronze}
+                  athleteId={Number(params.id)}
+                  podiumPosition="TERCEIRO"
                 />
               </div>
               {renderAthleteInfo()}

--- a/src/components/medalSection/index.tsx
+++ b/src/components/medalSection/index.tsx
@@ -15,9 +15,9 @@ const positionMapping: Record<string, string> = {
 };
 
 const highlightStyles: Record<string, string> = {
-  PRIMEIRO: "border-4 border-yellow-500 bg-yellow-200 shadow-md",
-  SEGUNDO: "border-4 border-gray-500 bg-gray-200 shadow-md",
-  TERCEIRO: "border-4 border-amber-600 bg-amber-200 shadow-md",
+  PRIMEIRO: "border-4 border-yellow-500 bg-yellow-300 shadow-md",
+  SEGUNDO: "border-4 border-gray-500 bg-gray-300 shadow-md",
+  TERCEIRO: "border-4 border-amber-500 bg-amber-500 shadow-md",
 };
 
 interface Campeonato {

--- a/src/components/medalSection/index.tsx
+++ b/src/components/medalSection/index.tsx
@@ -1,26 +1,145 @@
-import React from "react";
+import clsx from "clsx";
+import React, { useState, useEffect } from "react";
+import Modal from "../modal";
+import { getCampeonatosByAtleta } from "@/api/endpoints";
+import dayjs from "dayjs";
+import "dayjs/locale/pt-br";
+import Link from "next/link";
 
-type MedalSectionProps = {
+dayjs.locale("pt-br");
+
+const positionMapping: Record<string, string> = {
+  PRIMEIRO: "1º Lugar",
+  SEGUNDO: "2º Lugar",
+  TERCEIRO: "3º Lugar",
+};
+
+const highlightStyles: Record<string, string> = {
+  PRIMEIRO: "border-4 border-yellow-500 bg-yellow-200 shadow-md",
+  SEGUNDO: "border-4 border-gray-500 bg-gray-200 shadow-md",
+  TERCEIRO: "border-4 border-amber-600 bg-amber-200 shadow-md",
+};
+
+interface Campeonato {
+  name: string;
+  date: string;
+  posicaoPodium: string;
+}
+
+interface MedalSectionProps {
   imgSrc: string;
   altText: string;
   ringColor: string;
   medalCount: number;
-};
+  athleteId: number;
+  podiumPosition: "PRIMEIRO" | "SEGUNDO" | "TERCEIRO";
+}
 
-const MedalSection = ({ imgSrc, altText, ringColor, medalCount }: MedalSectionProps) => {
-  const ringClass = `hover:ring-2 hover:ring-${ringColor}`;
-  
+const MedalSection = ({ imgSrc, altText, ringColor, medalCount, athleteId, podiumPosition }: MedalSectionProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [championships, setChampionships] = useState<Campeonato[]>([]);
+  const [selectedPosition, setSelectedPosition] = useState<string>(podiumPosition);
+
+  useEffect(() => {
+    if (isOpen) {
+      setIsLoading(true);
+      getCampeonatosByAtleta(athleteId)
+        .then((response: { data: { nome: string; data: string; posicaoPodium: string }[] }) => {
+          const data = response.data.map((champ) => ({
+            name: champ.nome,
+            date: dayjs(champ.data).format("DD/MM/YYYY"),
+            posicaoPodium: champ.posicaoPodium,
+          }));
+          setChampionships(data);
+          setSelectedPosition(podiumPosition);
+        })
+        .catch((error: unknown) => {
+          console.error("Erro ao buscar campeonatos:", error);
+        })
+        .finally(() => {
+          setIsLoading(false);
+        });
+    }
+  }, [isOpen, athleteId, podiumPosition]);
+
   return (
-    <section className={`${ringClass} rounded-lg`}>
-      <img
-        src={imgSrc}
-        alt={altText}
-        className="transition delay-100 duration-300 ease-in-out hover:skew-y-6 hover:invert rounded-lg p-1 object-contain w-14 h-14 lg:w-20 lg:h-20"
-      />
-      <div className="lg:text-xl text-white font-semibold text-center">
-        {medalCount}
-      </div>
-    </section>
+    <>
+      <section 
+        className="cursor-pointer"
+        onClick={() => setIsOpen(true)}
+      >
+        <img
+          src={imgSrc}
+          alt={altText}
+          className={clsx(
+            "object-contain rounded-lg transition hover:ring-2 p-1 w-14 h-14 lg:w-20 lg:h-20",
+            {
+              "hover:ring-yellow-400": ringColor === "gold",
+              "hover:ring-gray-400": ringColor === "silver",
+              "hover:ring-amber-600": ringColor === "bronze",
+            }
+          )}
+        />
+        <div className="lg:text-xl text-white font-semibold text-center">{medalCount}</div>
+      </section>
+
+      {isOpen && (
+        <Modal 
+          title="Campeonatos" 
+          closeModalFunction={() => setIsOpen(false)} 
+          showCloseIcon={true} 
+          imageSrc="/icons/campeonato.png" 
+          imageLink={`${athleteId}/cadastrar/campeonato`}
+        >
+          {isLoading ? (
+            <p>Carregando...</p>
+          ) : championships.length === 0 ? (
+            <div className="text-center">
+              <p className="text-lg text-gray-700 font-semibold">
+                Este atleta ainda não possui medalhas.
+              </p>
+              <p className="text-gray-600 mt-2">
+                Deseja adicionar um novo campeonato?
+              </p>
+              <Link 
+                href={`${athleteId}/cadastrar/campeonato`}
+                className="mt-4 inline-block bg-winePattern text-white px-4 py-2 rounded-md hover:bg-opacity-80 transition"
+              >
+                Adicionar Campeonato
+              </Link>
+            </div>
+          ) : (
+            Object.entries(
+              championships.reduce((acc: Record<string, Campeonato[]>, champ) => {
+                if (!acc[champ.posicaoPodium]) {
+                  acc[champ.posicaoPodium] = [];
+                }
+                acc[champ.posicaoPodium].push(champ);
+                return acc;
+              }, {})
+            ).map(([position, champs]) => (
+              <div 
+                key={position} 
+                className={clsx(
+                  "mt-4 p-3 rounded-lg transition-all duration-300 ease-in-out",
+                  selectedPosition === position ? highlightStyles[position] : "border border-gray-200"
+                )}
+                onClick={() => setSelectedPosition(position)}
+              >
+                <h3 className="text-lg font-bold text-center">{positionMapping[position] || position}</h3>
+                <hr className="my-2 border-gray-300" />
+                {champs.map((champ, index) => (
+                  <p key={index} className="text-sm text-center">
+                    <span className="font-semibold">{champ.name}</span> - {champ.date}
+                  </p>
+                ))}
+              </div>
+            ))
+          )}
+        </Modal>
+      )}
+    </>
   );
 };
 

--- a/src/components/modal/index.tsx
+++ b/src/components/modal/index.tsx
@@ -1,6 +1,8 @@
+import React, { useEffect } from "react";
 import Button from "../ui/button";
+import Link from "next/link";
 
-type ModalProps = {
+interface ModalProps {
   title: string;
   text?: string;
   closeModalFunction: () => void;
@@ -9,7 +11,10 @@ type ModalProps = {
   confirmButtonText?: string;
   cancelButtonText?: string;
   showCloseIcon?: boolean;
-};
+  imageSrc?: string;
+  imageLink?: string;
+  children?: React.ReactNode;
+}
 
 const Modal = ({
   title,
@@ -20,53 +25,62 @@ const Modal = ({
   confirmButtonText = "Confirmar",
   cancelButtonText = "Cancelar",
   showCloseIcon = true,
+  children,
+  imageSrc,
+  imageLink,
 }: ModalProps) => {
+  
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        closeModalFunction();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [closeModalFunction]);
+
   return (
-    <div className="relative w-scren min-h-screen flex items-center justify-center">
-      <div className="absolute m-auto mx-auto z-20 lg:max-w-[650px] md:max-w-[500px] sm:max-w-[350px] max-w-[350px] flex items-center justify-center bg-white rounded-md xl:p-10 lg:p-8 md:p-5 p-5">
-        <div>
-          {showCloseIcon && (
-            <button
-              onClick={closeModalFunction}
-              className="absolute block xl:top-[7px] lg:top-[6px] md:top-[5px] top-[5px] xl:right-[10px] lg:right-[9px] md:right-[8px] right-[8px] text-winePattern font-bold xl:text-sm lg:text-xs md:text-xs text-xs p-1"
-            >
-              X
-            </button>
+    <div className="fixed inset-0 flex items-center justify-center z-50 bg-black bg-opacity-50" onClick={closeModalFunction}>
+      <div className="relative bg-white rounded-md xl:p-10 lg:p-8 md:p-5 p-5 shadow-lg w-full max-w-md" onClick={(e) => e.stopPropagation()}>
+        
+        {imageSrc && (
+          imageLink ? (
+            <Link href={imageLink}>
+              <img src={imageSrc} alt="Ícone" className="absolute top-3 left-3 w-8 h-8 cursor-pointer" />
+            </Link>
+          ) : (
+            <img src={imageSrc} alt="Ícone" className="absolute top-3 left-3 w-8 h-8" />
+          )
+        )}
+
+        {showCloseIcon && (
+          <button
+            onClick={closeModalFunction}
+            className="absolute top-3 right-3 text-winePattern font-bold text-xl"
+          >
+            X
+          </button>
+        )}
+
+        <h3 className="text-2xl text-winePattern font-bold text-center uppercase">{title}</h3>
+
+        {text && <p className="text-left text-base mt-4">{text}</p>}
+
+        <div className="mt-4">{children}</div>
+
+        <div className="flex flex-col-reverse mt-6 gap-y-4 md:flex-row justify-center items-center">
+          {cancelButtonFunction && (
+            <Button text={cancelButtonText} onClick={cancelButtonFunction} type="button" />
           )}
-
-          <h3 className="xl:text-2xl lg:text-xl md:text-lg text-lg text-winePattern font-bold text-center uppercase">
-            {title}
-          </h3>
-
-          {text && (
-            <p className="text-left xl:text-base lg:text-sm md:text-xs text-xs xl:mt-4 lg:mt-3 md:mt-2 mt-2">
-              {text}
-            </p>
+          {confirmButtonFunction && (
+            <Button text={confirmButtonText} onClick={confirmButtonFunction} type="button" />
           )}
-
-          <div className="flex flex-1 flex-col-reverse mt-12 gap-y-6 gap-x-10 md:flex-row justify-center items-center">
-            {cancelButtonFunction && (
-              <Button
-                text={cancelButtonText}
-                onClick={cancelButtonFunction}
-                type={"button"}
-              />
-            )}
-
-            {confirmButtonFunction && (
-              <Button
-                text={confirmButtonText}
-                onClick={confirmButtonFunction}
-                type={"button"}
-              />
-            )}
-          </div>
         </div>
       </div>
-      <div
-        className="absolute z-10 top-0 bottom-0 left-0 right-0 w-scren min-h-screen"
-        onClick={closeModalFunction}
-      ></div>
     </div>
   );
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -759,6 +759,11 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@vercel/speed-insights@^1.0.12":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@vercel/speed-insights/-/speed-insights-1.2.0.tgz#1656c3596d4ec02d93d301ca45944c1b9b245186"
+  integrity sha512-y9GVzrUJ2xmgtQlzFP2KhVRoCglwfRQgjyfY607aU0hh0Un6d0OUyrJkjuAlsV18qR4zfoFPs/BiIj9YDS6Wzw==
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"


### PR DESCRIPTION
###  🏆 Adicionar Modal de Campeonatos do Atleta
📌 Descrição
Este PR adiciona um modal exibindo os campeonatos conquistados pelo atleta ao clicar em suas medalhas. Os campeonatos são organizados por posição no pódio (1º, 2º e 3º lugar) e mostram o nome e a data formatada (DD/MM/YYYY).

🎯 Como Testar
- Acesse o perfil de um atleta.
- Clique em uma medalha (ouro, prata ou bronze).
O modal deve exibir corretamente os campeonatos.
- Pressione ESC ou clique fora do modal para fechá-lo.

![image](https://github.com/user-attachments/assets/584ded76-f0f4-40f6-84d4-558d165e54bd)

![image](https://github.com/user-attachments/assets/1cf9014f-7645-48be-81e3-73db555ccbc6)


